### PR TITLE
Add more voicing modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased 2.1] - TODO
 
 ### Added
-- 2 and 6 voice polyphonic modes (via F5 and F6 fat mode).
+- 2 and 6 voice polyphonic modes (via F5 fat mode).
+- 3-voice 2-operator polyphonic mode (via F6 fat mode in paraphonic mode).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased 2.1] - TODO
+
+### Added
+- 2 and 6 voice polyphonic modes (via F5 and F6 fat mode).
+
+### Fixed
+
+### Changed
+
+### Removed
+
 ## [Unreleased 2.0] - 2023-02-14
 
 ### Fixed

--- a/include/globals.h
+++ b/include/globals.h
@@ -42,3 +42,6 @@ extern byte preset;
 
 extern byte arp_output_note;
 extern optional<byte> control_voltage_note;
+
+// voice_index[operator] tells you the preset's voice to read the operator's settings from.
+extern byte* voice_index; // array of size 6, set depending on preset.paraphonic

--- a/include/preset.h
+++ b/include/preset.h
@@ -55,7 +55,7 @@ struct PresetLfo {
 
 enum class FilterMode { LOWPASS, BANDPASS, HIGHPASS, NOTCH, OFF };
 
-enum class FatMode { UNISONO, OCTAVE_UP, DETUNE_SLIGHT, DETUNE_MUCH };
+enum class FatMode { UNISONO, OCTAVE_UP, DETUNE_SLIGHT, DETUNE_MUCH, MORE_VOICES, PARA_2OP };
 
 struct Preset {
 	PresetVoice voice[3];

--- a/include/preset.h
+++ b/include/preset.h
@@ -42,6 +42,8 @@ struct PresetVoice {
 	}
 
 	uint8_t shape() const { return reg_control & (TRI | SAW | PULSE | NOISE); }
+
+	bool wants_filter() const { return filter_enabled && shape() != 0; }
 };
 
 struct PresetLfo {

--- a/include/preset.h
+++ b/include/preset.h
@@ -77,4 +77,5 @@ struct Preset {
 	FatMode fat_mode = FatMode::UNISONO;
 
 	uint16_t fatten_pitch(uint16_t pitch) const;
+	bool is_polyphonic() const { return paraphonic || fat_mode == FatMode::MORE_VOICES; }
 };

--- a/include/voice_allocation.hpp
+++ b/include/voice_allocation.hpp
@@ -60,7 +60,7 @@ template <size_t N> class PolyVoiceAllocator {
 		max_voices = value;
 		next_slot %= max_voices;
 
-		for (int i = max_voices; i < N; i++) {
+		for (auto i = max_voices; i < N; i++) {
 			voices[i].playing = false;
 		}
 	}

--- a/include/voice_state.hpp
+++ b/include/voice_state.hpp
@@ -42,6 +42,7 @@ template <size_t N_OPERATORS> struct VoiceState {
 			mono_tracker[i].clear();
 		}
 		mono_note_tracker.clear();
+		voice_allocator.set_max_voices(n);
 		voice_allocator.clear();
 	}
 
@@ -112,6 +113,9 @@ template <size_t N_OPERATORS> struct VoiceState {
 			} else {
 				return mono_note;
 			}
+		} else if (n_individual_voices == 2) {
+			int voice = oper / 3;
+			return voice_allocator.get_voices()[voice].note;
 		} else {
 			int voice = oper % n_individual_voices;
 			return voice_allocator.get_voices()[voice].note;
@@ -124,6 +128,9 @@ template <size_t N_OPERATORS> struct VoiceState {
 
 		if (n_individual_voices == 1) {
 			return mono_tracker[oper].has_active_note() || mono_note_tracker.has_active_note();
+		} else if (n_individual_voices == 2) {
+			int voice = oper / 3;
+			return voice_allocator.get_voices()[voice].playing;
 		} else {
 			int voice = oper % n_individual_voices;
 			return voice_allocator.get_voices()[voice].playing;
@@ -140,7 +147,7 @@ template <size_t N_OPERATORS> struct VoiceState {
 	uint8_t mono_note = 0;
 
 	MonoNoteTracker<16> mono_tracker[N_OPERATORS];
-	PolyVoiceAllocator<3> voice_allocator;
+	PolyVoiceAllocator<6> voice_allocator;
 	MonoNoteTracker<16> mono_note_tracker;
 
 	bool _held_keys[128] = {false};

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -63,3 +63,6 @@ int arpStepBase;
 bool arpModeHeld;
 byte arp_output_note;
 optional<byte> control_voltage_note;
+
+// voice_index[operator] tells you the preset's voice to read the operator's settings from.
+byte* voice_index; // array of size 6, set depending on preset.paraphonic

--- a/src/isr.cpp
+++ b/src/isr.cpp
@@ -177,9 +177,7 @@ void isr() {
 	// in monophonic mode, we glide only while the old note is still held down.
 	bool skip_glide = !preset_data.paraphonic && voice_state.n_held_keys() <= 1;
 	for (int i = 0; i < 6; i++) {
-		// FIXME this should be read from a mapping array and not be computed here.
-		int voice_idx = preset_data.paraphonic ? 0 : (i < 3 ? i : (i - 3));
-		glide[i].glide_tick(skip_glide ? 0 : preset_data.voice[voice_idx].glide);
+		glide[i].glide_tick(skip_glide ? 0 : preset_data.voice[voice_index[i]].glide);
 	}
 
 	// LFO

--- a/src/isr.cpp
+++ b/src/isr.cpp
@@ -175,7 +175,7 @@ void isr() {
 	}
 	// glides
 	// in monophonic mode, we glide only while the old note is still held down.
-	bool skip_glide = !preset_data.paraphonic && voice_state.n_held_keys() <= 1;
+	bool skip_glide = !preset_data.is_polyphonic() && voice_state.n_held_keys() <= 1;
 	for (int i = 0; i < 6; i++) {
 		glide[i].glide_tick(skip_glide ? 0 : preset_data.voice[voice_index[i]].glide);
 	}

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -81,9 +81,9 @@ void setSidRegisters(Preset const& preset, ParamsAfterLfo const& params_after_lf
 		// disable voice->filter routing if voice is off or filter is off.
 		sid_chips[i].set_resonance_and_filter_enable(
 		    params_after_lfo.resonance,
-		    preset.voice[0].filter_enabled && preset.filter_mode != FilterMode::OFF && preset.voice[0].shape() != 0,
-		    preset.voice[1].filter_enabled && preset.filter_mode != FilterMode::OFF && preset.voice[1].shape() != 0,
-		    preset.voice[2].filter_enabled && preset.filter_mode != FilterMode::OFF && preset.voice[2].shape() != 0,
+		    preset.voice[voice_index[3 * i + 0]].wants_filter() && preset.filter_mode != FilterMode::OFF,
+		    preset.voice[voice_index[3 * i + 1]].wants_filter() && preset.filter_mode != FilterMode::OFF,
+		    preset.voice[voice_index[3 * i + 2]].wants_filter() && preset.filter_mode != FilterMode::OFF,
 		    preset.filter_mode != FilterMode::OFF);
 		sid_chips[i].set_filter_cutoff(params_after_lfo.cutoff);
 

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -44,7 +44,7 @@ static void calculatePitch() {
 
 	for (int oper = 0; oper < 6; oper++) {
 		int oper_mod3 = oper < 3 ? oper : (oper - 3);
-		int voice_knob_idx = preset_data.paraphonic ? 0 : oper_mod3;
+		int voice_knob_idx = voice_index[oper];
 		int key;
 		if (preset_data.arp_mode) {
 			key = arp_output_note;
@@ -64,8 +64,9 @@ static void calculatePitch() {
 void setSidRegisters(Preset const& preset, ParamsAfterLfo const& params_after_lfo) {
 	for (int i = 0; i < 2; i++) {
 		for (int v = 0; v < 3; v++) {
-			int pv = preset_data.paraphonic ? 0 : v;
 			int oper = v + 3 * i;
+			int pv = voice_index[oper];
+
 			sid_chips[i].set_attack_decay(v, preset.voice[pv].attack, preset.voice[pv].decay);
 			sid_chips[i].set_sustain_release(v, preset.voice[pv].sustain, preset.voice[pv].release);
 			sid_chips[i].set_pulsewidth(v, params_after_lfo.pulsewidth[pv]);
@@ -158,7 +159,29 @@ void loop() {
 
 	readMux();
 
-	voice_state.set_n_individual_voices(preset_data.paraphonic ? 3 : 1);
+	static byte voice_index_000000[6] = {0, 0, 0, 0, 0, 0};
+	static byte voice_index_000111[6] = {0, 0, 0, 1, 1, 1};
+	static byte voice_index_012012[6] = {0, 1, 2, 0, 1, 2};
+	if (!preset_data.paraphonic) {
+		if (preset_data.fat_mode == FatMode::MORE_VOICES) {
+			voice_state.set_n_individual_voices(2);
+			voice_index = voice_index_012012;
+		} else {
+			voice_state.set_n_individual_voices(1);
+			voice_index = voice_index_012012;
+		}
+	} else {
+		if (preset_data.fat_mode == FatMode::MORE_VOICES) {
+			voice_state.set_n_individual_voices(6);
+			voice_index = voice_index_000000;
+		} else if (preset_data.fat_mode == FatMode::PARA_2OP) {
+			voice_state.set_n_individual_voices(3);
+			voice_index = voice_index_000111;
+		} else {
+			voice_state.set_n_individual_voices(3);
+			voice_index = voice_index_000000;
+		}
+	}
 	ParamsAfterLfo params_after_lfo = lfoTick();
 	calculatePitch();
 	setSidRegisters(preset_data, params_after_lfo);

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -127,7 +127,7 @@ void loop() {
 	}
 
 	bool control_voltage_gate = (PINA & _BV(7)) == 0;
-	if (control_voltage_gate && !preset_data.paraphonic) {
+	if (control_voltage_gate && !preset_data.is_polyphonic()) {
 		mux(15);
 		control_voltage_note = map(analogRead(A2), 0, 1023, 12, 72);
 	} else {

--- a/src/midi.cpp
+++ b/src/midi.cpp
@@ -68,7 +68,7 @@ static void HandleNoteOn(byte channel, byte note, byte velocity) {
 			default:
 				break;
 		}
-	} else if (!preset_data.paraphonic && masterChannel == 1 && (channel == 2 || channel == 3 || channel == 4)) {
+	} else if (!preset_data.is_polyphonic() && masterChannel == 1 && (channel == 2 || channel == 3 || channel == 4)) {
 		auto voice = channel - 2;
 
 		if (velocity) {

--- a/src/preset.cpp
+++ b/src/preset.cpp
@@ -88,7 +88,7 @@ void save() {
 	writey(preset_data.voice[1].reg_control);
 	writey(preset_data.voice[2].reg_control);
 	temp = 0;
-	temp |= ((int)preset_data.fat_mode) & 0x3;
+	temp |= ((int)preset_data.fat_mode) & 0x7;
 
 	writey(temp);
 	writey(preset_data.voice[0].fine_base * 255);
@@ -314,7 +314,7 @@ void load(byte number) {
 	}
 
 	temp = ready();
-	preset_data.fat_mode = uint2FatMode(temp & 0x3);
+	preset_data.fat_mode = uint2FatMode(temp & 0x7);
 
 	preset_data.voice[0].fine_base = ready();
 	preset_data.voice[0].fine_base /= 255;

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -63,7 +63,10 @@ void ui_tick() {
 		if (arpModeCounter > 16000) {
 			fatChanged = true;
 			arpModeCounter = 0;
-			preset_data.fat_mode = static_cast<FatMode>(((int)preset_data.fat_mode + 1) % 4);
+			if (preset_data.paraphonic)
+				preset_data.fat_mode = static_cast<FatMode>(((int)preset_data.fat_mode + 1) % 6);
+			else
+				preset_data.fat_mode = static_cast<FatMode>(((int)preset_data.fat_mode + 1) % 5);
 		}
 	}
 

--- a/src/ui_controller.cpp
+++ b/src/ui_controller.cpp
@@ -37,25 +37,33 @@ void UiDisplayController::update_leds(const Preset& p, const UiState& ui_state) 
 	assert(ui_state.lastPot <= 20);
 	assert(ui_state.selectedLfo < 3);
 
+	int n_unisono_voices;
+	if (!p.paraphonic)
+		n_unisono_voices = 3;
+	else if (p.fat_mode != FatMode::PARA_2OP)
+		n_unisono_voices = 1;
+	else
+		n_unisono_voices = 2;
+
 	if (!ui_state.filterModeHeld) {
 		for (int i = 0; i < 3; i++) {
-			set_led(4 * i + 1, p.voice[p.paraphonic ? 0 : i].reg_control & PresetVoice::PULSE);
-			set_led(4 * i + 2, p.voice[p.paraphonic ? 0 : i].reg_control & PresetVoice::TRI);
-			set_led(4 * i + 3, p.voice[p.paraphonic ? 0 : i].reg_control & PresetVoice::SAW);
-			set_led(4 * i + 4, p.voice[p.paraphonic ? 0 : i].reg_control & PresetVoice::NOISE);
+			set_led(4 * i + 1, i < n_unisono_voices && p.voice[i].reg_control & PresetVoice::PULSE);
+			set_led(4 * i + 2, i < n_unisono_voices && p.voice[i].reg_control & PresetVoice::TRI);
+			set_led(4 * i + 3, i < n_unisono_voices && p.voice[i].reg_control & PresetVoice::SAW);
+			set_led(4 * i + 4, i < n_unisono_voices && p.voice[i].reg_control & PresetVoice::NOISE);
 		}
 	} else {
 		for (int i = 0; i < 3; i++)
 			for (int k = 0; k < 4; k++)
-				set_led(4 * i + 1 + k, p.voice[p.paraphonic ? 0 : i].filter_enabled);
+				set_led(4 * i + 1 + k, i < n_unisono_voices && p.voice[i].filter_enabled);
 	}
 
-	set_led(16, bitRead(p.voice[p.paraphonic ? 0 : 0].reg_control, 1));
-	set_led(17, bitRead(p.voice[p.paraphonic ? 0 : 0].reg_control, 2));
-	set_led(18, bitRead(p.voice[p.paraphonic ? 0 : 1].reg_control, 1));
-	set_led(19, bitRead(p.voice[p.paraphonic ? 0 : 1].reg_control, 2));
-	set_led(20, bitRead(p.voice[p.paraphonic ? 0 : 2].reg_control, 1));
-	set_led(21, bitRead(p.voice[p.paraphonic ? 0 : 2].reg_control, 2));
+	set_led(16, 0 < n_unisono_voices && bitRead(p.voice[0].reg_control, 1));
+	set_led(17, 0 < n_unisono_voices && bitRead(p.voice[0].reg_control, 2));
+	set_led(18, 1 < n_unisono_voices && bitRead(p.voice[1].reg_control, 1));
+	set_led(19, 1 < n_unisono_voices && bitRead(p.voice[1].reg_control, 2));
+	set_led(20, 2 < n_unisono_voices && bitRead(p.voice[2].reg_control, 1));
+	set_led(21, 2 < n_unisono_voices && bitRead(p.voice[2].reg_control, 2));
 
 	switch (p.filter_mode) {
 		case FilterMode::LOWPASS:


### PR DESCRIPTION
Adds three additional voicing modes:

- 2 polyphonic 3-op voices (non-paraphonic mode, but fat mode set to F5)
- 6 polyphonic 1-op voices (paraphonic mode, but fat mode set to F5)
- 3 polyphonic 2-op voices (paraphonic mode, but fat mode set to F6)

Changes display in paraphonic mode: Only one LED bank is used instead of all three displaying the same.

Closes #9, closes #16.