### PR TITLE
Fixed bug #33, now allowing reading back FAT modes above 4

### DIFF
--- a/src/preset.cpp
+++ b/src/preset.cpp
@@ -49,7 +49,7 @@ static FilterMode uint2FilterMode(uint8_t i) {
 }
 
 static FatMode uint2FatMode(uint8_t i) {
-	if (i < 4) {
+	if (i < 6) {
 		return static_cast<FatMode>(i);
 	} else {
 		return FatMode::UNISONO;


### PR DESCRIPTION
Fixed the issue as of bug #33, where FAT modes above a certain range could no't be read back.