### PR TITLE
Refactor boot animation, reducing binary size and avoiding copy-paste

### DIFF
--- a/src/boot.cpp
+++ b/src/boot.cpp
@@ -8,135 +8,34 @@ void showVersion() {
 	leftDot();
 }
 
-// boot animation
-static byte del = 20; // sets the animation speed
+// IDs for LEDs per column, separated by zeroes
+const byte ledOrder[] = {
+    1,  5,  9,  0, 2,  6,  10, 27, 28, 29, 0, 3,  7, 11, 13, 0,  4,  8, 12, 0,  14, 0,
+    16, 18, 20, 0, 17, 19, 21, 15, 0,  22, 0, 23, 0, 24, 0,  25, 30, 0, 26, 31, 0,
+};
 
+// boot animation
 void boot() {
 
+	// Animate each LED column, one at a time
 	bool state = true;
-
-	ledSet(1, state);
-	ledSet(5, state);
-	ledSet(9, state);
-
-	delay(del);
-	state = !state;
-	ledSet(1, state);
-	ledSet(5, state);
-	ledSet(9, state);
-
-	delay(del);
-	state = !state;
-	ledSet(2, state);
-	ledSet(6, state);
-	ledSet(10, state);
-	ledSet(27, state);
-	ledSet(28, state);
-	ledSet(29, state);
-	delay(del);
-	state = !state;
-	ledSet(2, state);
-	ledSet(6, state);
-	ledSet(10, state);
-	ledSet(27, state);
-	ledSet(28, state);
-	ledSet(29, state);
-	delay(del);
-	state = !state;
-
-	ledSet(3, state);
-	ledSet(7, state);
-	ledSet(11, state);
-	ledSet(13, state);
-	delay(del);
-	state = !state;
-
-	ledSet(3, state);
-	ledSet(7, state);
-	ledSet(11, state);
-	ledSet(13, state);
-	delay(del);
-	state = !state;
-
-	ledSet(4, state);
-	ledSet(8, state);
-	ledSet(12, state);
-	delay(del);
-	state = !state;
-
-	ledSet(4, state);
-	ledSet(8, state);
-	ledSet(12, state);
-	delay(del);
-	state = !state;
-
-	ledSet(14, state);
-	delay(del);
-	state = !state;
-	ledSet(14, state);
-	delay(del);
-	state = !state;
-
-	ledSet(16, state);
-	ledSet(18, state);
-	ledSet(20, state);
-	delay(del);
-	state = !state;
-	ledSet(16, state);
-	ledSet(18, state);
-	ledSet(20, state);
-	delay(del);
-	state = !state;
-
-	ledSet(17, state);
-	ledSet(19, state);
-	ledSet(21, state);
-	ledSet(15, state);
-	delay(del);
-	state = !state;
-	ledSet(17, state);
-	ledSet(19, state);
-	ledSet(21, state);
-	ledSet(15, state);
-	delay(del);
-	state = !state;
-
-	ledSet(22, state);
-	delay(del);
-	state = !state;
-	ledSet(22, state);
-	delay(del);
-	state = !state;
-
-	ledSet(23, state);
-	delay(del);
-	state = !state;
-	ledSet(23, state);
-	delay(del);
-	state = !state;
-
-	ledSet(24, state);
-	delay(del);
-	state = !state;
-	ledSet(24, state);
-	delay(del);
-	state = !state;
-
-	ledSet(25, state);
-	ledSet(30, state);
-	delay(del);
-	state = !state;
-	ledSet(25, state);
-	ledSet(30, state);
-	delay(del);
-	state = !state;
-
-	ledSet(26, state);
-	ledSet(31, state);
-	delay(del);
-	state = !state;
-	ledSet(26, state);
-	ledSet(31, state);
-	delay(del);
-	state = !state;
+	byte i, j;
+	i = j = 0;
+	do {
+		if (ledOrder[i] != 0) {
+			ledSet(ledOrder[i], state);
+			i++;
+		} else {
+			if (state) {
+				// Column is now on, do same one again to turn it off
+				i = j;
+			} else {
+				// Column is now off, continue to next column
+				i++;
+				j = i;
+			}
+			delay(20);
+			state = !state;
+		}
+	} while (i < sizeof(ledOrder));
 }


### PR DESCRIPTION
This refactors the boot animation by removing duplicated code. Functionality is same as before but memory footprint is now about 650 bytes less (1.5K smaller SYX file).