### PR TITLE
Fixed bug #44 - EEPROM Clash preset99 globals

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -58,3 +58,19 @@ extern optional<byte> control_voltage_note;
 
 // voice_index[operator] tells you the preset's voice to read the operator's settings from.
 extern byte* voice_index; // array of size 6, set depending on preset.paraphonic
+
+// Memory Mapping
+#define EEPROM_ADDR_PRESET_LAST 3999
+#define EEPROM_ADDR_MIDI_IN_CH_MASTER 3998
+#define EEPROM_ADDR_MIDI_OUT_CH_MASTER 3997
+#define EEPROM_ADDR_SEND_LFO 3996
+#define EEPROM_ADDR_SEND_ARP 3995
+#define EEPROM_ADDR_MW_TO_LFO1 3994
+#define EEPROM_ADDR_AT_TO_LFO2 3993
+#define EEPROM_ADDR_VEL_TO_LFO3 3992
+#define EEPROM_ADDR_MASTER_VOLUME 3991
+#define EEPROM_ADDR_PW_LIMIT 3990
+#define EEPROM_ADDR_MIDI_IN_CH_VOICE1 3989
+#define EEPROM_ADDR_MIDI_IN_CH_VOICE2 3988
+#define EEPROM_ADDR_MIDI_IN_CH_VOICE3 3987
+#define EEPROM_ADDR_ARMSID_MODE 3986

--- a/include/globals.h
+++ b/include/globals.h
@@ -8,7 +8,6 @@ template <typename T> class optional;
 extern Preset preset_data;
 extern VoiceState<6> voice_state;
 extern Glide glide[6];
-extern byte settings;
 extern byte aftertouch;
 extern bool aftertouchToLfo;
 extern bool sendLfo;
@@ -23,7 +22,7 @@ extern bool armSID;
 extern bool cvActive[3];
 extern int lfoStep[3];
 extern byte lfo[3];
-extern int velocityToLfo;
+extern bool velocityToLfo;
 extern bool modToLfo;
 extern byte velocityLast;
 extern byte modWheelLast;
@@ -59,18 +58,38 @@ extern optional<byte> control_voltage_note;
 // voice_index[operator] tells you the preset's voice to read the operator's settings from.
 extern byte* voice_index; // array of size 6, set depending on preset.paraphonic
 
-// Memory Mapping
-#define EEPROM_ADDR_PRESET_LAST 3999
-#define EEPROM_ADDR_MIDI_IN_CH_MASTER 3998
-#define EEPROM_ADDR_MIDI_OUT_CH_MASTER 3997
-#define EEPROM_ADDR_SEND_LFO 3996
-#define EEPROM_ADDR_SEND_ARP 3995
-#define EEPROM_ADDR_MW_TO_LFO1 3994
-#define EEPROM_ADDR_AT_TO_LFO2 3993
-#define EEPROM_ADDR_VEL_TO_LFO3 3992
-#define EEPROM_ADDR_MASTER_VOLUME 3991
-#define EEPROM_ADDR_PW_LIMIT 3990
-#define EEPROM_ADDR_MIDI_IN_CH_VOICE1 3989
-#define EEPROM_ADDR_MIDI_IN_CH_VOICE2 3988
-#define EEPROM_ADDR_MIDI_IN_CH_VOICE3 3987
-#define EEPROM_ADDR_ARMSID_MODE 3986
+// EEPROM Memory Mapping
+#define EEPROM_ADDR_COOKIE 0x0000  // Two bytes
+#define EEPROM_ADDR_VERSION 0x0002 // Two bytes
+#define EEPROM_ADDR_PRESET_LAST 0x0004
+#define EEPROM_ADDR_MIDI_IN_CH_MASTER 0x0005
+#define EEPROM_ADDR_MIDI_OUT_CH_MASTER 0x0006
+#define EEPROM_ADDR_SEND_LFO 0x0007
+#define EEPROM_ADDR_SEND_ARP 0x0008
+#define EEPROM_ADDR_MW_TO_LFO1 0x0009
+#define EEPROM_ADDR_AT_TO_LFO2 0x000a
+#define EEPROM_ADDR_VEL_TO_LFO3 0x000b
+#define EEPROM_ADDR_MASTER_VOLUME 0x000c
+#define EEPROM_ADDR_PW_LIMIT 0x000d
+#define EEPROM_ADDR_MIDI_IN_CH_VOICE1 0x000e
+#define EEPROM_ADDR_MIDI_IN_CH_VOICE2 0x000f
+#define EEPROM_ADDR_MIDI_IN_CH_VOICE3 0x0010
+#define EEPROM_ADDR_ARMSID_MODE 0x0011
+#define EEPROM_ADDR_PRESET_DATA_START 0x0028
+#define EEPROM_ADDR_PRESET(preset) (EEPROM_ADDR_PRESET_DATA_START + (preset - 1) * PRESET_DATA_SIZE)
+
+#define EEPROM_COOKIE_VALUE (uint16_t)19028
+#define EEPROM_FORMAT_VERSION (uint16_t)0x0001
+
+// Global settings, stored in EEPROM
+struct globalSetting {
+	void* variable;
+	uint16_t eepromAddress;
+	byte minValue;
+	byte maxValue;
+	byte defaultValue;
+	byte ccMessageToolMode;
+	bool isChannel;
+};
+
+extern const globalSetting globalSettings[14];

--- a/include/preset.h
+++ b/include/preset.h
@@ -2,8 +2,8 @@
 #include <stdint.h>
 #include <Arduino.h>
 
-#define PRESET_NUMBER_LOWEST 1
-#define PRESET_NUMBER_HIGHEST 99
+#define PRESET_NUMBER_MIN 1
+#define PRESET_NUMBER_MAX 99
 #define PRESET_DATA_SIZE 40
 
 void save();

--- a/include/preset.h
+++ b/include/preset.h
@@ -2,6 +2,10 @@
 #include <stdint.h>
 #include <Arduino.h>
 
+#define PRESET_NUMBER_LOWEST 1
+#define PRESET_NUMBER_HIGHEST 99
+#define PRESET_DATA_SIZE 40
+
 void save();
 void load(byte number);
 void saveChannels();

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -6,7 +6,6 @@ UiState ui_state;
 bool sendLfo = false;
 bool sendArp = false;
 bool pwLimit;
-byte settings;
 bool lfoNewRand[3];
 byte aftertouch;      // latest read afterTouch value
 bool aftertouchToLfo; // option to assign aftertouch to LFO depth 2
@@ -16,7 +15,7 @@ byte volume;
 float bend, bend1, bend2, bend3;
 bool sync;
 bool armSID;
-int velocityToLfo;
+bool velocityToLfo;
 bool toolMode; // when set high by MIDI tool we can receive settings via CC
 bool modToLfo;
 byte modWheelLast;
@@ -77,3 +76,25 @@ optional<byte> control_voltage_note;
 
 // voice_index[operator] tells you the preset's voice to read the operator's settings from.
 byte* voice_index; // array of size 6, set depending on preset.paraphonic
+
+// Global settings, ranges and where stored in EEPROM memory
+const globalSetting globalSettings[14] = {
+
+    {&modToLfo, EEPROM_ADDR_MW_TO_LFO1, 0, 1, true, 85, false},
+    {&aftertouchToLfo, EEPROM_ADDR_AT_TO_LFO2, 0, 1, true, 86, false},
+    {&velocityToLfo, EEPROM_ADDR_VEL_TO_LFO3, 0, 1, false, 87, false},
+    {&sendLfo, EEPROM_ADDR_SEND_LFO, 0, 1, false, 92, false},
+    {&sendArp, EEPROM_ADDR_SEND_ARP, 0, 1, false, 93, false},
+    {&pwLimit, EEPROM_ADDR_PW_LIMIT, 0, 1, true, 88, false},
+    {&armSID, EEPROM_ADDR_ARMSID_MODE, 0, 1, false, 97, false},
+
+    {&masterChannel, EEPROM_ADDR_MIDI_IN_CH_MASTER, 1, 16, 1, 90, true},
+    {&masterChannelOut, EEPROM_ADDR_MIDI_OUT_CH_MASTER, 1, 16, 1, 91, true},
+    {&voice1Channel, EEPROM_ADDR_MIDI_IN_CH_VOICE1, 1, 16, 2, 94, true},
+    {&voice2Channel, EEPROM_ADDR_MIDI_IN_CH_VOICE2, 1, 16, 3, 95, true},
+    {&voice3Channel, EEPROM_ADDR_MIDI_IN_CH_VOICE3, 1, 16, 4, 96, true},
+
+    {&volume, EEPROM_ADDR_MASTER_VOLUME, 1, 15, 15, 89, false},
+    {&preset, EEPROM_ADDR_PRESET_LAST, PRESET_NUMBER_MIN, PRESET_NUMBER_MAX, PRESET_NUMBER_MIN, 255, false},
+
+};

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -119,7 +119,7 @@ void loop() {
 		// update volume
 		sid_chips[0].set_volume(volume);
 		sid_chips[1].set_volume(volume);
-		EEPROM.update(3991, volume);
+		EEPROM.update(EEPROM_ADDR_MASTER_VOLUME, volume);
 		volumeChanged = false;
 	}
 

--- a/src/midi.cpp
+++ b/src/midi.cpp
@@ -132,37 +132,37 @@ static void HandleControlChange(byte channel, byte data1, byte data2) {
 	lastData2 = data2;
 	if (channel == 16 && toolMode && data1 == 85) {
 		if (data2) {
-			EEPROM.update(3994, 1);
+			EEPROM.update(EEPROM_ADDR_MW_TO_LFO1, 1);
 			modToLfo = 1;
 		} else {
-			EEPROM.update(3994, 0);
+			EEPROM.update(EEPROM_ADDR_MW_TO_LFO1, 0);
 			modToLfo = 0;
 		}
 	} // mod wheel -> lfo depth1
 	else if (channel == 16 && toolMode && data1 == 86) {
 		if (data2) {
-			EEPROM.update(3993, 1);
+			EEPROM.update(EEPROM_ADDR_AT_TO_LFO2, 1);
 			aftertouchToLfo = 1;
 		} else {
-			EEPROM.update(3993, 0);
+			EEPROM.update(EEPROM_ADDR_AT_TO_LFO2, 0);
 			aftertouchToLfo = 0;
 		}
 	} // aftertouch -> lfo depth2
 	else if (channel == 16 && toolMode && data1 == 87) {
 		if (data2) {
-			EEPROM.update(3992, 1);
+			EEPROM.update(EEPROM_ADDR_VEL_TO_LFO3, 1);
 			velocityToLfo = 1;
 		} else {
-			EEPROM.update(3992, 0);
+			EEPROM.update(EEPROM_ADDR_VEL_TO_LFO3, 0);
 			velocityToLfo = 0;
 		}
 	} // velocity -> lfo depth3
 	else if (channel == 16 && toolMode && data1 == 88) {
 		if (data2) {
-			EEPROM.update(3990, 1);
+			EEPROM.update(EEPROM_ADDR_PW_LIMIT, 1);
 			pwLimit = 1;
 		} else {
-			EEPROM.update(3990, 0);
+			EEPROM.update(EEPROM_ADDR_PW_LIMIT, 0);
 			pwLimit = 0;
 		}
 	} // pwLimit
@@ -173,66 +173,66 @@ static void HandleControlChange(byte channel, byte data1, byte data2) {
 		if ((volume > 15) || (volume < 1)) {
 			volume = 15;
 		}
-		EEPROM.update(3991, volume);
+		EEPROM.update(EEPROM_ADDR_MASTER_VOLUME, volume);
 	} // master volume
 
 	else if (channel == 16 && toolMode && data1 == 90) {
 		if (data2 < 16) {
-			EEPROM.update(3998, data2 + 1);
+			EEPROM.update(EEPROM_ADDR_MIDI_IN_CH_MASTER, data2 + 1);
 			masterChannel = data2 + 1;
 		}
 	} // master input channel
 
 	else if (channel == 16 && toolMode && data1 == 91) {
 		if (data2 < 16) {
-			EEPROM.update(3997, data2 + 1);
+			EEPROM.update(EEPROM_ADDR_MIDI_OUT_CH_MASTER, data2 + 1);
 			masterChannelOut = data2 + 1;
 		}
 	} // master output channel
 	else if (channel == 16 && toolMode && data1 == 92) {
 		if (data2) {
-			EEPROM.update(3996, 1);
+			EEPROM.update(EEPROM_ADDR_SEND_LFO, 1);
 			sendLfo = 1;
 		} else {
-			EEPROM.update(3996, 0);
+			EEPROM.update(EEPROM_ADDR_SEND_LFO, 0);
 			sendLfo = 0;
 		}
 	} // lfo transmits CC
 	else if (channel == 16 && toolMode && data1 == 94) {
 		if (data2 < 16) {
-			EEPROM.update(3989, data2 + 1);
+			EEPROM.update(EEPROM_ADDR_MIDI_IN_CH_VOICE1, data2 + 1);
 			voice1Channel = data2 + 1;
 		}
 	} // master output channel voice1
 	else if (channel == 16 && toolMode && data1 == 95) {
 		if (data2 < 16) {
-			EEPROM.update(3988, data2 + 1);
+			EEPROM.update(EEPROM_ADDR_MIDI_IN_CH_VOICE2, data2 + 1);
 			voice2Channel = data2 + 1;
 		}
 	} // master output channel voice2
 	else if (channel == 16 && toolMode && data1 == 96) {
 		if (data2 < 16) {
-			EEPROM.update(3987, data2 + 1);
+			EEPROM.update(EEPROM_ADDR_MIDI_IN_CH_VOICE3, data2 + 1);
 			voice3Channel = data2 + 1;
 		}
 	} // master output channel voice3
 
 	else if (channel == 16 && toolMode && data1 == 93) {
 		if (data2) {
-			EEPROM.update(3995, 1);
+			EEPROM.update(EEPROM_ADDR_SEND_ARP, 1);
 			sendArp = true;
 		} else {
-			EEPROM.update(3995, 0);
+			EEPROM.update(EEPROM_ADDR_SEND_ARP, 0);
 			sendArp = false;
 		}
 	} // arp transmits MIDI notes
 
 	else if (channel == 16 && toolMode && data1 == 97) {
 		if (data2) {
-			EEPROM.update(3986, 1);
+			EEPROM.update(EEPROM_ADDR_ARMSID_MODE, 1);
 			armSID = true;
 		} else {
-			EEPROM.update(3986, 0);
+			EEPROM.update(EEPROM_ADDR_ARMSID_MODE, 0);
 			armSID = false;
 		}
 	} // ARMSID mode
@@ -290,29 +290,29 @@ static void HandleControlChange(byte channel, byte data1, byte data2) {
 				case 68:
 					if (data2) {
 						sendLfo = true;
-						EEPROM.update(3996, 0);
+						EEPROM.update(EEPROM_ADDR_SEND_LFO, 0);
 					} else {
 						sendLfo = false;
-						EEPROM.update(3996, 1);
+						EEPROM.update(EEPROM_ADDR_SEND_LFO, 1);
 					}
 					break; // lfo send
 				case 69:
 					if (data2) {
 						sendArp = true;
-						EEPROM.update(3995, 0);
+						EEPROM.update(EEPROM_ADDR_SEND_ARP, 0);
 					} else {
 						sendArp = false;
-						EEPROM.update(3995, 1);
+						EEPROM.update(EEPROM_ADDR_SEND_ARP, 1);
 					}
 					break; // arp send
 
 				case 85:
 					if (data2) {
 						sendArp = true;
-						EEPROM.update(3995, 0);
+						EEPROM.update(EEPROM_ADDR_SEND_ARP, 0);
 					} else {
 						sendArp = false;
-						EEPROM.update(3995, 1);
+						EEPROM.update(EEPROM_ADDR_SEND_ARP, 1);
 					}
 					break; // arp send
 			}
@@ -516,8 +516,8 @@ void midiRead() {
 					case 6:
 						if (mChannel == masterChannel) {
 							preset = input + 1;
-							if (preset > 99) {
-								preset = 1;
+							if (preset > PRESET_NUMBER_HIGHEST) {
+								preset = PRESET_NUMBER_LOWEST;
 							}
 						}
 						mData = 0;
@@ -617,7 +617,8 @@ void recieveDump() {
 	byte ledLast = 0;
 	for (int i = 0; i < 4000; i++) {
 
-		if ((i != 3998) && (i != 3997)) { // don't overWrite MIDI channels!!
+		if ((i != EEPROM_ADDR_MIDI_IN_CH_MASTER) &&
+		    (i != EEPROM_ADDR_MIDI_OUT_CH_MASTER)) { // don't overWrite MIDI channels!!
 			EEPROM.update(i, mem[i]);
 			if (ledLast != i / 40) {
 				ledLast = i / 40;

--- a/src/midi.cpp
+++ b/src/midi.cpp
@@ -130,114 +130,30 @@ static void HandleControlChange(byte channel, byte data1, byte data2) {
 
 	lastData1 = data1;
 	lastData2 = data2;
-	if (channel == 16 && toolMode && data1 == 85) {
-		if (data2) {
-			EEPROM.update(EEPROM_ADDR_MW_TO_LFO1, 1);
-			modToLfo = 1;
-		} else {
-			EEPROM.update(EEPROM_ADDR_MW_TO_LFO1, 0);
-			modToLfo = 0;
-		}
-	} // mod wheel -> lfo depth1
-	else if (channel == 16 && toolMode && data1 == 86) {
-		if (data2) {
-			EEPROM.update(EEPROM_ADDR_AT_TO_LFO2, 1);
-			aftertouchToLfo = 1;
-		} else {
-			EEPROM.update(EEPROM_ADDR_AT_TO_LFO2, 0);
-			aftertouchToLfo = 0;
-		}
-	} // aftertouch -> lfo depth2
-	else if (channel == 16 && toolMode && data1 == 87) {
-		if (data2) {
-			EEPROM.update(EEPROM_ADDR_VEL_TO_LFO3, 1);
-			velocityToLfo = 1;
-		} else {
-			EEPROM.update(EEPROM_ADDR_VEL_TO_LFO3, 0);
-			velocityToLfo = 0;
-		}
-	} // velocity -> lfo depth3
-	else if (channel == 16 && toolMode && data1 == 88) {
-		if (data2) {
-			EEPROM.update(EEPROM_ADDR_PW_LIMIT, 1);
-			pwLimit = 1;
-		} else {
-			EEPROM.update(EEPROM_ADDR_PW_LIMIT, 0);
-			pwLimit = 0;
-		}
-	} // pwLimit
+	if (channel == 16 && toolMode) {
+		byte prevVolume = volume;
 
-	else if (channel == 16 && toolMode && data1 == 89) {
-		volumeChanged = true;
-		volume = data2;
-		if ((volume > 15) || (volume < 1)) {
-			volume = 15;
-		}
-		EEPROM.update(EEPROM_ADDR_MASTER_VOLUME, volume);
-	} // master volume
+		// Go through all global settings and check if the tool requested to change one
+		for (int i = 0; i < (int)(sizeof(globalSettings) / sizeof(globalSetting)); i++) {
+			const globalSetting* setting = &(globalSettings[i]);
 
-	else if (channel == 16 && toolMode && data1 == 90) {
-		if (data2 < 16) {
-			EEPROM.update(EEPROM_ADDR_MIDI_IN_CH_MASTER, data2 + 1);
-			masterChannel = data2 + 1;
-		}
-	} // master input channel
+			if (setting->ccMessageToolMode == data1) {
 
-	else if (channel == 16 && toolMode && data1 == 91) {
-		if (data2 < 16) {
-			EEPROM.update(EEPROM_ADDR_MIDI_OUT_CH_MASTER, data2 + 1);
-			masterChannelOut = data2 + 1;
-		}
-	} // master output channel
-	else if (channel == 16 && toolMode && data1 == 92) {
-		if (data2) {
-			EEPROM.update(EEPROM_ADDR_SEND_LFO, 1);
-			sendLfo = 1;
-		} else {
-			EEPROM.update(EEPROM_ADDR_SEND_LFO, 0);
-			sendLfo = 0;
-		}
-	} // lfo transmits CC
-	else if (channel == 16 && toolMode && data1 == 94) {
-		if (data2 < 16) {
-			EEPROM.update(EEPROM_ADDR_MIDI_IN_CH_VOICE1, data2 + 1);
-			voice1Channel = data2 + 1;
-		}
-	} // master output channel voice1
-	else if (channel == 16 && toolMode && data1 == 95) {
-		if (data2 < 16) {
-			EEPROM.update(EEPROM_ADDR_MIDI_IN_CH_VOICE2, data2 + 1);
-			voice2Channel = data2 + 1;
-		}
-	} // master output channel voice2
-	else if (channel == 16 && toolMode && data1 == 96) {
-		if (data2 < 16) {
-			EEPROM.update(EEPROM_ADDR_MIDI_IN_CH_VOICE3, data2 + 1);
-			voice3Channel = data2 + 1;
-		}
-	} // master output channel voice3
+				if (setting->isChannel) {
+					// If the setting is a MIDI channel, adjust for internal representation
+					data2++;
+				}
 
-	else if (channel == 16 && toolMode && data1 == 93) {
-		if (data2) {
-			EEPROM.update(EEPROM_ADDR_SEND_ARP, 1);
-			sendArp = true;
-		} else {
-			EEPROM.update(EEPROM_ADDR_SEND_ARP, 0);
-			sendArp = false;
+				// Validate range and update only if valid
+				if ((data2 >= setting->minValue) && (data2 <= setting->maxValue)) {
+					*(byte*)(setting->variable) = data2;
+					EEPROM.update(setting->eepromAddress, data2);
+				}
+			}
 		}
-	} // arp transmits MIDI notes
 
-	else if (channel == 16 && toolMode && data1 == 97) {
-		if (data2) {
-			EEPROM.update(EEPROM_ADDR_ARMSID_MODE, 1);
-			armSID = true;
-		} else {
-			EEPROM.update(EEPROM_ADDR_ARMSID_MODE, 0);
-			armSID = false;
-		}
-	} // ARMSID mode
-
-	else if (channel == masterChannel) {
+		volumeChanged = (volume != prevVolume);
+	} else if (channel == masterChannel) {
 		if (data1 == 59)
 			data1 = 32;
 
@@ -288,32 +204,16 @@ static void HandleControlChange(byte channel, byte data1, byte data2) {
 					break;
 
 				case 68:
-					if (data2) {
-						sendLfo = true;
-						EEPROM.update(EEPROM_ADDR_SEND_LFO, 0);
-					} else {
-						sendLfo = false;
-						EEPROM.update(EEPROM_ADDR_SEND_LFO, 1);
-					}
+					// TODO: Why CC 68? Manual says 61
+					sendLfo = (data2 > 0);
+					EEPROM.update(EEPROM_ADDR_SEND_LFO, sendLfo);
 					break; // lfo send
-				case 69:
-					if (data2) {
-						sendArp = true;
-						EEPROM.update(EEPROM_ADDR_SEND_ARP, 0);
-					} else {
-						sendArp = false;
-						EEPROM.update(EEPROM_ADDR_SEND_ARP, 1);
-					}
-					break; // arp send
 
+				case 69:
 				case 85:
-					if (data2) {
-						sendArp = true;
-						EEPROM.update(EEPROM_ADDR_SEND_ARP, 0);
-					} else {
-						sendArp = false;
-						EEPROM.update(EEPROM_ADDR_SEND_ARP, 1);
-					}
+					// TODO: Why CC 69 and 85? Manual says 62
+					sendArp = (data2 > 0);
+					EEPROM.update(EEPROM_ADDR_SEND_ARP, sendArp);
 					break; // arp send
 			}
 		}
@@ -516,8 +416,8 @@ void midiRead() {
 					case 6:
 						if (mChannel == masterChannel) {
 							preset = input + 1;
-							if (preset > PRESET_NUMBER_HIGHEST) {
-								preset = PRESET_NUMBER_LOWEST;
+							if (preset > PRESET_NUMBER_MAX) {
+								preset = PRESET_NUMBER_MIN;
 							}
 						}
 						mData = 0;

--- a/src/preset.cpp
+++ b/src/preset.cpp
@@ -62,7 +62,7 @@ static int ready() {
 
 void save() {
 	byte temp;
-	writeIndex = preset * PRESET_DATA_SIZE;
+	writeIndex = EEPROM_ADDR_PRESET(preset);
 
 	bitWrite(preset_data.voice[0].reg_control, 0, 0);
 	bitWrite(preset_data.voice[1].reg_control, 0, 0);
@@ -227,7 +227,7 @@ void load(byte number) {
 	Serial1.end();
 	Timer1.stop(); //
 
-	writeIndex = number * 40;
+	writeIndex = EEPROM_ADDR_PRESET(number);
 	byte temp;
 
 	preset_data.voice[0].reg_control = ready();

--- a/src/preset.cpp
+++ b/src/preset.cpp
@@ -7,39 +7,6 @@
 #include "util.hpp"
 #include "globals.h"
 
-/*
-
-MEMORY MAPPING
-(0-3960) 99 PRESETS = 40 bytes
-
-3999 PRESET LAST
-
-3998 MIDI IN MASTER CHANNEL
-3997 MIDI OUT MASTER CHANNEL
-
-3996 SEND LFO
-3995 SEND ARP
-
- OPTIONS
-set via the online webmidi tool
-twisted-electrons.com/tool
-
-3994:Mod Wheel -> LFO1 depth
-3993:AfterTouch -> LFO2 depth
-3992:Velocity -> LFO3 depth
-
-3991 = master volume
-
-3990 = pwLimit //allow PW to silence the voice?
-
-3989 MIDI in voice1
-3988 MIDI in voice2
-3987 MIDI in voice3
-
-3986 ARMSID mode
-
-*/
-
 static FilterMode uint2FilterMode(uint8_t i) {
 	if (i < 5) {
 		return static_cast<FilterMode>(i);
@@ -95,7 +62,7 @@ static int ready() {
 
 void save() {
 	byte temp;
-	writeIndex = preset * 40;
+	writeIndex = preset * PRESET_DATA_SIZE;
 
 	bitWrite(preset_data.voice[0].reg_control, 0, 0);
 	bitWrite(preset_data.voice[1].reg_control, 0, 0);
@@ -619,6 +586,6 @@ void load(byte number) {
 
 void saveChannels() {
 
-	EEPROM.update(3998, masterChannel);
-	EEPROM.update(3997, masterChannelOut);
+	EEPROM.update(EEPROM_ADDR_MIDI_IN_CH_MASTER, masterChannel);
+	EEPROM.update(EEPROM_ADDR_MIDI_OUT_CH_MASTER, masterChannelOut);
 }

--- a/src/tsid.cpp
+++ b/src/tsid.cpp
@@ -110,16 +110,16 @@ void setup() {
 
 	int preset_tmp;
 	preset_tmp = EEPROM.read(3999);
-	if (preset_tmp > 98)
+	if ((preset_tmp > 99) || (preset_tmp < 1))
 		preset_tmp = 1;
 	preset = preset_tmp;
 
 	masterChannel = EEPROM.read(3998);
-	if (masterChannel > 16) {
+	if ((masterChannel > 16) || (masterChannel < 1)) {
 		masterChannel = 1;
 	}
 	masterChannelOut = EEPROM.read(3997);
-	if (masterChannelOut > 16) {
+	if ((masterChannelOut > 16) || (masterChannelOut < 1)) {
 		masterChannelOut = 1;
 	}
 

--- a/src/tsid.cpp
+++ b/src/tsid.cpp
@@ -18,8 +18,8 @@ tools/hex2sysex/hex2sysex.py --syx -o firmware.syx TSID.ino.hex
 TO DO:
 Add setup mode (hold arp mode for 2 seconds), press again to exit (same as megaFM)
 -MIDI channel learn (map input to ouput channel)
--in setup mode use a button (square 1?) to toggle LFO MIDI CC send on/off EEPROM 3996
--in setup mode uss a button (triangle 1?) to toggle ARP MIDI send on/off EEPROM 3995
+-in setup mode use a button (square 1?) to toggle LFO MIDI CC send on/off EEPROM_ADDR_SEND_LFO
+-in setup mode uss a button (triangle 1?) to toggle ARP MIDI send on/off EEPROM_ADDR_SEND_ARP
 -add 6 voice mode using 2 chips, I suggest we hold a waveform for several seconds for 3 voice paramode, hold it longer
 for 6 (show P3, then P6 on display) -kill the voices when they are done singing by setting the freq to 0. Never tried
 this (too dumb to figure out when the ADSR is finished), but I read it's a solution against the ghost notes (leaky VCA)
@@ -103,77 +103,77 @@ void setup() {
 
 	DDRC = B11111000;
 
-	volume = EEPROM.read(3991);
+	volume = EEPROM.read(EEPROM_ADDR_MASTER_VOLUME);
 	if ((volume > 15) || (volume < 1))
 		volume = 15; // let's avoid silent sids!!!
 	volumeChanged = true;
 
 	int preset_tmp;
-	preset_tmp = EEPROM.read(3999);
-	if ((preset_tmp > 99) || (preset_tmp < 1))
-		preset_tmp = 1;
+	preset_tmp = EEPROM.read(EEPROM_ADDR_PRESET_LAST);
+	if ((preset_tmp > PRESET_NUMBER_HIGHEST) || (preset_tmp < PRESET_NUMBER_LOWEST))
+		preset_tmp = PRESET_NUMBER_LOWEST;
 	preset = preset_tmp;
 
-	masterChannel = EEPROM.read(3998);
+	masterChannel = EEPROM.read(EEPROM_ADDR_MIDI_IN_CH_MASTER);
 	if ((masterChannel > 16) || (masterChannel < 1)) {
 		masterChannel = 1;
 	}
-	masterChannelOut = EEPROM.read(3997);
+	masterChannelOut = EEPROM.read(EEPROM_ADDR_MIDI_OUT_CH_MASTER);
 	if ((masterChannelOut > 16) || (masterChannelOut < 1)) {
 		masterChannelOut = 1;
 	}
 
-	if (EEPROM.read(3986) > 0) {
+	if (EEPROM.read(EEPROM_ADDR_ARMSID_MODE) > 0) {
 		armSID = false;
 	} else {
 		armSID = true;
 	}
-	if (EEPROM.read(3996) > 0) {
+	if (EEPROM.read(EEPROM_ADDR_SEND_LFO) > 0) {
 		sendLfo = false;
 	} else {
 		sendLfo = true;
 	}
-	if (EEPROM.read(3995) > 0) {
+	if (EEPROM.read(EEPROM_ADDR_SEND_ARP) > 0) {
 		sendArp = false;
 	} else {
 		sendArp = true;
 	}
 
-	if (EEPROM.read(3994) > 0) {
+	if (EEPROM.read(EEPROM_ADDR_MW_TO_LFO1) > 0) {
 		modToLfo = true;
 	} else {
 		modToLfo = false;
 	}
 
-	if (EEPROM.read(3993) > 0) {
+	if (EEPROM.read(EEPROM_ADDR_AT_TO_LFO2) > 0) {
 		aftertouchToLfo = true;
 	} else {
 		aftertouchToLfo = false;
 	}
 
-	if (EEPROM.read(3992) > 0) {
+	if (EEPROM.read(EEPROM_ADDR_VEL_TO_LFO3) > 0) {
 		velocityToLfo = true;
 	} else {
 		velocityToLfo = false;
 	}
 
-	if (EEPROM.read(3990) > 0) {
+	if (EEPROM.read(EEPROM_ADDR_PW_LIMIT) > 0) {
 		pwLimit = true;
 	} else {
 		pwLimit = false;
 	}
 
-	voice1Channel = EEPROM.read(3989);
+	voice1Channel = EEPROM.read(EEPROM_ADDR_MIDI_IN_CH_VOICE1);
 	if ((voice1Channel > 16) || (voice1Channel < 1)) {
 		voice1Channel = 2;
 	}
 
-	voice2Channel = EEPROM.read(3988);
+	voice2Channel = EEPROM.read(EEPROM_ADDR_MIDI_IN_CH_VOICE2);
 	if ((voice2Channel > 16) || (voice1Channel < 1)) {
 		voice2Channel = 3;
 	}
 
-	voice3Channel = EEPROM.read(3987);
+	voice3Channel = EEPROM.read(EEPROM_ADDR_MIDI_IN_CH_VOICE3);
 	if ((voice3Channel > 16) || (voice1Channel < 1)) {
 		voice3Channel = 4;
 	}

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -30,7 +30,7 @@ void ui_loop() {
 		loadTimer = 800;
 		load(preset);
 		presetLast = preset;
-		EEPROM.update(3999, presetLast);
+		EEPROM.update(EEPROM_ADDR_PRESET_LAST, presetLast);
 	}
 	if (saveBounce)
 		saveBounce--;
@@ -67,8 +67,8 @@ void ui_tick() {
 					presetScrollSpeed -= 1000;
 				}
 				preset++;
-				if (preset > 99) {
-					preset = 1;
+				if (preset > PRESET_NUMBER_HIGHEST) {
+					preset = PRESET_NUMBER_LOWEST;
 				}
 				scrolled = true;
 			}
@@ -80,8 +80,8 @@ void ui_tick() {
 					presetScrollSpeed -= 1000;
 				}
 				preset--;
-				if (preset < 1) {
-					preset = 99;
+				if (preset < PRESET_NUMBER_LOWEST) {
+					preset = PRESET_NUMBER_HIGHEST;
 				}
 				scrolled = true;
 			}

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -67,8 +67,8 @@ void ui_tick() {
 					presetScrollSpeed -= 1000;
 				}
 				preset++;
-				if (preset > PRESET_NUMBER_HIGHEST) {
-					preset = PRESET_NUMBER_LOWEST;
+				if (preset > PRESET_NUMBER_MAX) {
+					preset = PRESET_NUMBER_MIN;
 				}
 				scrolled = true;
 			}
@@ -80,8 +80,8 @@ void ui_tick() {
 					presetScrollSpeed -= 1000;
 				}
 				preset--;
-				if (preset < PRESET_NUMBER_LOWEST) {
-					preset = PRESET_NUMBER_HIGHEST;
+				if (preset < PRESET_NUMBER_MIN) {
+					preset = PRESET_NUMBER_MAX;
 				}
 				scrolled = true;
 			}

--- a/src/ui_buttons.cpp
+++ b/src/ui_buttons.cpp
@@ -334,8 +334,8 @@ void buttChanged(byte number, bool value) {
 					presetScrollSpeed = 10000;
 					if ((!saveBounce) && (!loadTimer) && (!scrolled)) {
 						preset++;
-						if (preset > PRESET_NUMBER_HIGHEST) {
-							preset = PRESET_NUMBER_LOWEST;
+						if (preset > PRESET_NUMBER_MAX) {
+							preset = PRESET_NUMBER_MIN;
 						}
 					} else {
 						saveEngaged = false;
@@ -350,8 +350,8 @@ void buttChanged(byte number, bool value) {
 					presetScrollSpeed = 10000;
 					if ((!saveBounce) && (!loadTimer) && (!scrolled)) {
 						preset--;
-						if (preset < PRESET_NUMBER_LOWEST) {
-							preset = PRESET_NUMBER_HIGHEST;
+						if (preset < PRESET_NUMBER_MIN) {
+							preset = PRESET_NUMBER_MAX;
 						}
 					} else {
 						saveEngaged = false;

--- a/src/ui_buttons.cpp
+++ b/src/ui_buttons.cpp
@@ -334,8 +334,8 @@ void buttChanged(byte number, bool value) {
 					presetScrollSpeed = 10000;
 					if ((!saveBounce) && (!loadTimer) && (!scrolled)) {
 						preset++;
-						if (preset > 99) {
-							preset = 1;
+						if (preset > PRESET_NUMBER_HIGHEST) {
+							preset = PRESET_NUMBER_LOWEST;
 						}
 					} else {
 						saveEngaged = false;
@@ -350,8 +350,8 @@ void buttChanged(byte number, bool value) {
 					presetScrollSpeed = 10000;
 					if ((!saveBounce) && (!loadTimer) && (!scrolled)) {
 						preset--;
-						if (preset < 1) {
-							preset = 99;
+						if (preset < PRESET_NUMBER_LOWEST) {
+							preset = PRESET_NUMBER_HIGHEST;
 						}
 					} else {
 						saveEngaged = false;


### PR DESCRIPTION
Fix bug #44:
* Moved global settings from clashed area at preset 99 to start of memory (before preset 1)
* All addresses now use defines
* Introduced cookie header and format version to be able to convert data in the future if needed
* Refactored storage handling of global settings to reduce duplicate code and flash footprint, introducing min/max/default values as well.