### PR TITLE
Improved usage of EEPROM for extra storage

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -77,10 +77,16 @@ extern byte* voice_index; // array of size 6, set depending on preset.paraphonic
 #define EEPROM_ADDR_MIDI_IN_CH_VOICE3 0x0010
 #define EEPROM_ADDR_ARMSID_MODE 0x0011
 #define EEPROM_ADDR_PRESET_DATA_START 0x0028
+// block of main storage for presets
 #define EEPROM_ADDR_PRESET(preset) (EEPROM_ADDR_PRESET_DATA_START + (preset - 1) * PRESET_DATA_SIZE)
+// one extra byte of storage per preset - located at two different places (1-96, 97-99)
+#define EEPROM_ADDR_PRESET_EXTRA_BYTE(preset)                                                                          \
+	(preset <= 96) ? EEPROM_ADDR_PRESET_DATA_START + PRESET_NUMBER_MAX* PRESET_DATA_SIZE + preset - 1                  \
+	               : EEPROM_ADDR_PRESET_DATA_START + preset - 100
 
 #define EEPROM_COOKIE_VALUE (uint16_t)19028
-#define EEPROM_FORMAT_VERSION (uint16_t)0x0001
+#define EEPROM_FORMAT_VERSION_V1 (uint16_t)0x0001
+#define EEPROM_FORMAT_VERSION_V2 (uint16_t)0x0002
 
 // Global settings, stored in EEPROM
 struct globalSetting {

--- a/src/midi.cpp
+++ b/src/midi.cpp
@@ -464,8 +464,8 @@ void sendDump() {
 	digit(0, 5);
 	digit(1, 18);
 
-	byte mem[4000];
-	for (int i = 0; i < 4000; i++) {
+	byte mem[EEPROM.length()];
+	for (size_t i = 0; i < sizeof(mem) / sizeof(*mem); i++) {
 		mem[i] = EEPROM.read(i);
 	}
 	byte nill = 0;
@@ -475,7 +475,7 @@ void sendDump() {
 	Serial.write(100);
 	delay(1);
 
-	for (int i = 0; i < 4000; i++) {
+	for (size_t i = 0; i < sizeof(mem) / sizeof(*mem); i++) {
 
 		if (mem[i] > 127) {
 			Serial.write(mem[i] - 128);
@@ -494,7 +494,7 @@ void sendDump() {
 }
 
 void recieveDump() {
-	byte mem[4000];
+	byte mem[EEPROM.length()];
 	digit(0, 16);
 	digit(1, 18);
 
@@ -538,7 +538,7 @@ void recieveDump() {
 	}
 
 	byte ledLast = 0;
-	for (int i = 0; i < 4000; i++) {
+	for (size_t i = 0; i < sizeof(mem) / sizeof(*mem); i++) {
 
 		if ((i != EEPROM_ADDR_MIDI_IN_CH_MASTER) &&
 		    (i != EEPROM_ADDR_MIDI_OUT_CH_MASTER)) { // don't overWrite MIDI channels!!


### PR DESCRIPTION
* Using one extra byte per preset (located non-consecutively)
* Three bits used for filter voice enable (leaving five for future use)
* Stepped EEPROM structure to version V2, and includes conversion from V1 (defaulting to all voices filtered for all presets)
* Sysex memory dump now uses entire EEPROM
* Enabled LCD display during EEPROM dump