### PR TITLE
Add global setting to allow arp on one key

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -4,7 +4,7 @@
 #include "voice_state.hpp"
 
 template <typename T> class optional;
-
+extern bool noArp1key;
 extern Preset preset_data;
 extern VoiceState<6> voice_state;
 extern Glide glide[6];
@@ -87,6 +87,7 @@ extern byte* voice_index; // array of size 6, set depending on preset.paraphonic
 #define EEPROM_ADDR_PRESET_DATA_START 0x0028
 #define EEPROM_ADDR_PITCH_BEND_UP 0x0029
 #define EEPROM_ADDR_PITCH_BEND_DOWN 0x002a
+#define EEPROM_ADDR_NO_ARP_1_KEY 0x002b
 // block of main storage for presets
 #define EEPROM_ADDR_PRESET(preset) (EEPROM_ADDR_PRESET_DATA_START + (preset - 1) * PRESET_DATA_SIZE)
 // one extra byte of storage per preset - located at two different places (1-96, 97-99)
@@ -109,4 +110,4 @@ struct globalSetting {
 	bool isBaseOne;
 };
 
-extern const globalSetting globalSettings[16];
+extern const globalSetting globalSettings[17];

--- a/src/arp.cpp
+++ b/src/arp.cpp
@@ -78,7 +78,7 @@ void arpReset() {
 byte lastArpNote;
 
 void arpTick() {
-	if (voice_state.n_held_keys() > 0) {
+	if (voice_state.n_held_keys() > noArp1key) {
 		if (preset_data.arp_mode) {
 			if (preset_data.lfo[0].retrig || voice_state.n_held_keys() == 1) { // always retrigger on the first key
 				lfoStep[0] = 0;

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -7,6 +7,7 @@ bool sendLfo = false;
 bool sendArp = false;
 bool pwLimit;
 bool lfoNewRand[3];
+bool noArp1key;
 byte aftertouch;      // latest read afterTouch value
 bool aftertouchToLfo; // option to assign aftertouch to LFO depth 2
 int loadTimer;
@@ -86,7 +87,7 @@ optional<byte> control_voltage_note;
 byte* voice_index; // array of size 6, set depending on preset.paraphonic
 
 // Global settings, ranges and where stored in EEPROM memory
-const globalSetting globalSettings[16] = {
+const globalSetting globalSettings[17] = {
 
     {&modToLfo, EEPROM_ADDR_MW_TO_LFO1, 0, 1, true, 85, false},
     {&aftertouchToLfo, EEPROM_ADDR_AT_TO_LFO2, 0, 1, true, 86, false},
@@ -106,4 +107,5 @@ const globalSetting globalSettings[16] = {
     {&preset, EEPROM_ADDR_PRESET_LAST, PRESET_NUMBER_MIN, PRESET_NUMBER_MAX, PRESET_NUMBER_MIN, 255, false},
     {&pitchBendUp, EEPROM_ADDR_PITCH_BEND_UP, 1, 48, 2, 99, true},
     {&pitchBendDown, EEPROM_ADDR_PITCH_BEND_DOWN, 1, 48, 2, 100, true},
+    {&noArp1key, EEPROM_ADDR_NO_ARP_1_KEY, 0, 1, 0, 101, false},
 };

--- a/src/midi.cpp
+++ b/src/midi.cpp
@@ -130,6 +130,9 @@ static void HandleNoteOn(byte channel, byte note, byte velocity) {
 	if (channel == masterChannel) {
 		if (velocity) {
 			velocityLast = velocity;
+			if (voice_state.n_held_keys() < 1) {
+				arp_output_note = note + (arpRound * 12);
+			}
 		}
 
 		switch (voice_state.note_on(note, velocity)) {


### PR DESCRIPTION
Add global setting (in tool) to allow arp on one key
note changes on first key if arp active but stopped (previously it would hang on the last arp note)